### PR TITLE
Remove API from the AZ static webapp deploy workflow

### DIFF
--- a/.github/workflows/azure-static-web-apps-nice-beach-0bc3fc603.yml
+++ b/.github/workflows/azure-static-web-apps-nice-beach-0bc3fc603.yml
@@ -41,7 +41,7 @@ jobs:
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: "/" # App source code path
-          api_location: "./api" # Api source code path - optional
+          api_location: "" # Api source code path - optional
           output_location: "dist/angular-basic" # Built app content directory - optional
           github_id_token: ${{ steps.idtoken.outputs.result }}
           ###### End of Repository/Build Configurations ######


### PR DESCRIPTION
Remove managed Azure Functions API backend for the static webapp, and add the backend later as Azure Function.